### PR TITLE
Release v0.1.1 version flag

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Samiul Sk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ expose tunnel
 
 ## 📖 Usage
 
+### Version
+
+Check the version of expose:
+
+```
+expose --version
+# expose version v0.1.1 (commit: 4784595, built: 2025-11-07)
+```
+
 ### Initialize Project
 
 Create a `.expose.yml` configuration file:
@@ -128,6 +137,12 @@ Contributions welcome! This project follows:
 - Standard Go conventions
 - Commit message format: `type: description`
 - Clean, tested, documented code
+
+### Contributors
+
+- **Samiul Sk** - Project creator and maintainer
+
+*Want to contribute? See our [contributing guidelines](CONTRIBUTING.md) (coming soon)*
 
 ## 📝 License
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/kernelshard/expose/internal/version"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "expose",
-	Short: "Expose localhost to the internet",
-	Long:  "Minimal CLI to expose your local dev server",
+	Use:     "expose",
+	Short:   "Expose localhost to the internet",
+	Long:    "Minimal CLI to expose your local dev server",
+	Version: version.GetFullVersion(),
 }
 
 func Execute() error {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+var (
+	Version   = "v0.1.1"
+	GitCommit = "4784595"
+	BuildDate = "2025-11-07"
+)
+
+// GetVersion returns just the version string
+func GetVersion() string {
+	if Version == "dev" {
+		return "dev (unreleased)"
+	}
+	return Version
+}
+
+// GetFullVersion returns version with build metadata (for Cobra)
+// Note: Cobra automatically prefixes with "expose version"
+func GetFullVersion() string {
+	return GetVersion() + " (commit: " + GitCommit + ", built: " + BuildDate + ")"
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,23 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	v := GetVersion()
+	if !strings.Contains(v, Version) {
+		t.Errorf("GetVersion mismatch expected %s in:%s", Version, v)
+	}
+}
+
+func TestGetFullVersion(t *testing.T) {
+	fullVersion := GetFullVersion()
+	if !strings.Contains(fullVersion, GitCommit) {
+		t.Errorf("GetFullVersion call expected %s in %s", GitCommit, fullVersion)
+	}
+	if !strings.Contains(fullVersion, BuildDate) {
+		t.Errorf("GetFullVersion call expected %s in %s", BuildDate, fullVersion)
+	}
+}


### PR DESCRIPTION
## Release v0.1.1

### Changes
- ✅ Added --version flag (#11 )
- ✅ Shows version, commit, build date
- ✅ 75% test coverage