### PR TITLE
feat: Add self-hosted server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@
 | **No Signup Required** | ✅ | ❌ | ❌ | ✅ |
 | **Single Binary** | ✅ | ✅ | ✅ | ❌ (requires Node.js) |
 | **Open Source** | ✅ | ❌ | ✅ | ✅ |
+| **Self-Hosted Server** | ✅ | ❌ | ❌ | ❌ |
 | **Language** | Go | Go | Go | JS |
 | **Free Custom Domains** | 🚧 (Planned) | 💲 Paid | ✅ | ❌ |
 
 ## ✨ Features
 
-- 🌐 **Multiple Providers**: Switch between LocalTunnel and Cloudflare Tunnel instantly.
+- 🌐 **Multiple Providers**: LocalTunnel, Cloudflare, or your own **self-hosted server**.
+- 🏠 **Self-Hosted**: Run `expose server` on any $5 VPS — full control, no third parties.
 - ⚡ **Zero Friction**: No accounts, no auth tokens, just run and go.
 - 📦 **Lightweight**: A single <10MB binary with no external dependencies.
-- 🔧 **Developer Friendly**: Written in pure Go, easy to contribute to or self-host.
+- 🔧 **Developer Friendly**: Written in pure Go, easy to contribute to.
 
 ---
 
@@ -43,10 +45,20 @@ expose init
 expose tunnel
 ```
 
-### Or use Cloudflare limits
+### Or use Cloudflare
 ```bash
 expose tunnel -P cloudflare -p 8080
 ```
+
+### Or use your own self-hosted server
+```bash
+# On your VPS — one-time setup
+expose server --domain=tunnel.mysite.com --control-port=7890 --public-port=8080
+
+# On your laptop — just works
+expose tunnel --server=tunnel.mysite.com:7890
+```
+
 ---
 
 ### 📦 Installation
@@ -156,7 +168,8 @@ expose/
 ├── internal/
 │   ├── cli/          # Cobra commands (thin layer)
 │   ├── config/       # YAML config management
-│   ├── provider/     # Tunnel provider interface
+│   ├── provider/     # Tunnel provider implementations
+│   ├── server/       # Self-hosted tunnel server
 │   ├── tunnel/       # Service layer (business logic)
 │   └── version/      # Version metadata
 └── .expose.yml       # User config (add to .gitignore per project)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,6 +18,7 @@ func Execute() error {
 	// Add commands
 	rootCmd.AddCommand(newInitCmd())
 	rootCmd.AddCommand(newTunnelCmd())
+	rootCmd.AddCommand(newServerCmd())
 	rootCmd.AddCommand(newConfigCmd())
 
 	return rootCmd.Execute()

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kernelshard/expose/internal/server"
+)
+
+// newServerCmd creates the 'expose server' command.
+// it starts a self-hosted expose server.
+func newServerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Run a self-hosted expose server",
+		Long: `Start a self-hosted tunnel server on your VPS.
+				
+		Clients can connect using:
+			expose tunnel --server=yourdomain.com --provider=selfhosted
+		
+		Example:
+			expose server --domain=tunnel.mysite.com --control-port=7890 --public-port=8080`,
+		RunE: runServerCmd,
+	}
+
+	cmd.Flags().IntP("control-port", "c", 7890, "Port for client connections")
+	cmd.Flags().IntP("public-port", "p", 8080, "Port for public HTTP traffic")
+	cmd.Flags().StringP("domain", "d", "localhost", "Domain for public URLs")
+	return cmd
+}
+
+// runServerCmd runs the  self-hosted tunnel server.
+func runServerCmd(cmd *cobra.Command, _ []string) error {
+	domain, _ := cmd.Flags().GetString("domain")
+	controlPort, _ := cmd.Flags().GetInt("control-port")
+	publicPort, _ := cmd.Flags().GetInt("public-port")
+
+	srv := server.NewServer(domain, controlPort, publicPort)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-sigChan
+		fmt.Println("\nShutting down server...")
+		cancel()
+	}()
+
+	fmt.Printf("🚀 Expose server starting...\n")
+	return srv.Start(ctx)
+}

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -27,10 +27,14 @@ func newTunnelCmd() *cobra.Command {
 
 	// Define flags
 	// provider flag to specify provider e.g. expose tunnel --provider cloudflare
-	cmd.Flags().StringP("provider", "P", "localtunnel", "Tunnel provider: localtunnel, cloudflare, etc. defaults to localtunnel")
+	cmd.Flags().StringP("provider", "P", "localtunnel", "Tunnel provider: localtunnel, cloudflare, selfhosted")
 
 	// port flag to specify local port e.g. expose tunnel --port 8080
 	cmd.Flags().IntP("port", "p", 0, "Local port to expose (overrides config)")
+
+	// server flag for self-hosted provider. auto-selects selfhosted provider if set.
+	cmd.Flags().StringP("server", "s", "", "Self-hosted server address (e.g. tunnel.mysite.com:7890)")
+
 	return cmd
 }
 
@@ -61,24 +65,31 @@ func runTunnelCmd(cmd *cobra.Command, _ []string) error {
 	// use provider flag shorthand -P to select provider
 	providerName, err := cmd.Flags().GetString("provider")
 	if err != nil {
-		return fmt.Errorf("invalid port %d (must be 1-65535)", port)
+		return fmt.Errorf("invalid provider flag: %w", err)
 	}
 
-	return runTunnel(port, providerName)
-}
+	// Build the provider here (separation of concerns)
+	// If --server is set, auto-select selfhosted provider
+	serverAddr, _ := cmd.Flags().GetString("server")
+	if serverAddr != "" {
+		providerName = "selfhosted"
+	}
 
-// runTunnel sets up a reverse proxy to expose the local server
-// on the specified port.
-func runTunnel(port int, providerName string) error {
 	var svc *tunnel.Service
-
 	switch providerName {
 	case "cloudflare":
 		svc = tunnel.NewService(provider.NewCloudFlare())
+	case "selfhosted":
+		svc = tunnel.NewService(provider.NewSelfHosted(serverAddr))
 	default:
 		svc = tunnel.NewService(provider.NewLocalTunnel(nil))
-
 	}
+
+	return runTunnel(port, svc)
+}
+
+// runTunnel starts the tunnel service and waits for shutdown.
+func runTunnel(port int, svc *tunnel.Service) error {
 
 	// Setup ctx & signal handling
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/provider/selfhosted.go
+++ b/internal/provider/selfhosted.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/kernelshard/expose/internal/server/protocol"
+)
+
+// SelfHosted implements the Provider interface that connects to self-hosted expose server.
+type SelfHosted struct {
+	serverAddr string // e.g: tunnel.mysite.com:7890
+	conn       net.Conn
+	publicURL  string
+	connected  bool
+}
+
+// NewSelfHosted creates a new self-hosted provider.
+// publicURL and connected will be set after the first connection.
+func NewSelfHosted(serverAddr string) *SelfHosted {
+	return &SelfHosted{
+		serverAddr: serverAddr,
+	}
+}
+
+// Name returns the name of the provider.
+func (s *SelfHosted) Name() string {
+	return "selfhosted"
+}
+
+// Connect establishes a connection to the self-hosted server.
+// It sends a registration request and returns the public URL & set connection to
+// conn to user for further use.
+func (s *SelfHosted) Connect(ctx context.Context, localPort int) (string, error) {
+	// 1. Connect to server control plane
+	conn, err := net.Dial("tcp", s.serverAddr)
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to server %w", err)
+	}
+
+	// 2. Send registration request
+	req := protocol.RegisterRequest{} // empty = ask for random subdomain
+	if err := json.NewEncoder(conn).Encode(req); err != nil {
+		conn.Close()
+		return "", err
+	}
+	// 3. Read server response (we expect a RegisterResponse) which contains the public URL
+	var resp protocol.RegisterResponse
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		conn.Close()
+		return "", err
+	}
+
+	if resp.Error != "" {
+		conn.Close()
+		return "", fmt.Errorf("server error: %s", resp.Error)
+	}
+
+	// 4. Store state
+	s.publicURL = resp.PublicURL
+	s.connected = true
+	s.conn = conn
+
+	return s.publicURL, nil
+
+}
+
+// IsConnected returns true if the provider is connected to the server.
+func (s *SelfHosted) IsConnected() bool {
+	return s.connected
+}
+
+// PublicURL returns the public URL of the tunnel. e.g format: http://subdomain.domain.com:port
+func (s *SelfHosted) PublicURL() string {
+	return s.publicURL
+}
+
+// Close disconnects the tunnel and cleans up resources.
+func (s *SelfHosted) Close() error {
+	s.connected = false
+	s.publicURL = ""
+	if s.conn != nil {
+		return s.conn.Close()
+	}
+	return nil
+}

--- a/internal/provider/selfhosted.go
+++ b/internal/provider/selfhosted.go
@@ -19,6 +19,7 @@ type SelfHosted struct {
 
 // NewSelfHosted creates a new self-hosted provider.
 // publicURL and connected will be set after the first connection.
+// serverAddr is the address of the control plane. eg. localhost:7890
 func NewSelfHosted(serverAddr string) *SelfHosted {
 	return &SelfHosted{
 		serverAddr: serverAddr,

--- a/internal/provider/selfhosted.go
+++ b/internal/provider/selfhosted.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
+	"time"
 
 	"github.com/kernelshard/expose/internal/server/protocol"
 )
@@ -12,9 +14,11 @@ import (
 // SelfHosted implements the Provider interface that connects to self-hosted expose server.
 type SelfHosted struct {
 	serverAddr string // e.g: tunnel.mysite.com:7890
+	subdomain  string
 	conn       net.Conn
 	publicURL  string
 	connected  bool
+	// TODO: support concurrent requests like LocalTunnel (pre-open multiple data connections)
 }
 
 // NewSelfHosted creates a new self-hosted provider.
@@ -42,13 +46,13 @@ func (s *SelfHosted) Connect(ctx context.Context, localPort int) (string, error)
 	}
 
 	// 2. Send registration request
-	req := protocol.RegisterRequest{} // empty = ask for random subdomain
+	req := protocol.TunnelRequest{Type: protocol.TypeControl} // empty = ask for random subdomain
 	if err := json.NewEncoder(conn).Encode(req); err != nil {
 		conn.Close()
 		return "", err
 	}
 	// 3. Read server response (we expect a RegisterResponse) which contains the public URL
-	var resp protocol.RegisterResponse
+	var resp protocol.TunnelResponse
 	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
 		conn.Close()
 		return "", err
@@ -61,8 +65,12 @@ func (s *SelfHosted) Connect(ctx context.Context, localPort int) (string, error)
 
 	// 4. Store state
 	s.publicURL = resp.PublicURL
+	s.subdomain = resp.Subdomain
 	s.connected = true
 	s.conn = conn
+
+	// 5. Open data connections
+	go s.openDataConnections(ctx, localPort)
 
 	return s.publicURL, nil
 
@@ -86,4 +94,44 @@ func (s *SelfHosted) Close() error {
 		return s.conn.Close()
 	}
 	return nil
+}
+
+// openDataConnections opens a pool of TCP connections to the localtunnel server.
+// Each connection will handle incoming requests.
+// TODO: for now we only open one connection, but we should open multiple connections to handle concurrent requests
+func (s *SelfHosted) openDataConnections(ctx context.Context, localPort int) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		conn, err := net.Dial("tcp", s.serverAddr)
+		if err != nil {
+			continue
+		}
+		json.NewEncoder(conn).Encode(protocol.TunnelRequest{
+			Type:      protocol.TypeData,
+			Subdomain: s.subdomain,
+		})
+
+		go s.proxyRequest(conn, localPort)
+	}
+}
+
+// proxyRequest proxies traffic from the tunnel connection to the local server and vice versa.
+func (s *SelfHosted) proxyRequest(tunnelConn net.Conn, localPort int) {
+	defer tunnelConn.Close()
+
+	localAddr := fmt.Sprintf("localhost:%d", localPort)
+	localConn, err := net.DialTimeout("tcp", localAddr, 5*time.Second)
+	if err != nil {
+		return
+	}
+	defer localConn.Close()
+
+	// a. Start a background goroutine to pump data FROM local TO tunnel
+	go io.Copy(localConn, tunnelConn)
+	// b. Block the main thread pumping data FROM tunnel TO local
+	io.Copy(tunnelConn, localConn)
 }

--- a/internal/provider/selfhosted_test.go
+++ b/internal/provider/selfhosted_test.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kernelshard/expose/internal/server"
+)
+
+func TestSelfHosted_Connect(t *testing.T) {
+	// 1. start a real server locally
+	srv := server.NewServer("localhost", 0, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := srv.Start(ctx); err != nil {
+			t.Errorf("server error: %v", err)
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond) // wait for listeners
+
+	// 2. Get the control address from the server
+	controlAddr := srv.ControlAddr()
+
+	// 3. Connect via selfhosted provider
+	provider := NewSelfHosted(controlAddr)
+	url, errr := provider.Connect(ctx, 3000)
+	if errr != nil {
+		t.Errorf("Connect failed: %v", errr)
+	}
+
+	// 4. Verify the connection
+	if url == "" {
+		t.Fatal("expected public URL, got empty string")
+	}
+	if !provider.IsConnected() {
+		t.Fatal("expected IsConnected to be true")
+	}
+
+	// 5. Close the connection
+	if err := provider.Close(); err != nil {
+		t.Errorf("Close failed: %v", err)
+	}
+}

--- a/internal/server/protocol/protocol.go
+++ b/internal/server/protocol/protocol.go
@@ -1,0 +1,17 @@
+package protocol
+
+// RegisterRequest is sent by the client to register a tunnel.
+type RegisterRequest struct {
+	// Subdomain is the desired subdomain. If empty, server will assign a random one.
+	Subdomain string `json:"subdomain,omitempty"`
+}
+
+// RegisterResponse is sent by the server after registration.
+type RegisterResponse struct {
+	// Subdomain is the assigned subdomain.
+	Subdomain string `json:"subdomain"`
+	// PublicURL is the full URL to access the tunnel.
+	PublicURL string `json:"public_url"`
+	// Error is set if registration failed.
+	Error string `json:"error,omitempty"`
+}

--- a/internal/server/protocol/protocol.go
+++ b/internal/server/protocol/protocol.go
@@ -1,13 +1,20 @@
 package protocol
 
-// RegisterRequest is sent by the client to register a tunnel.
-type RegisterRequest struct {
+const (
+	TypeControl = "control"
+	TypeData    = "data"
+)
+
+// TunnelRequest is sent by the client when connecting to the server.
+// Type determines the purpose: TypeControl for registration, TypeData for proxying.
+type TunnelRequest struct {
 	// Subdomain is the desired subdomain. If empty, server will assign a random one.
 	Subdomain string `json:"subdomain,omitempty"`
+	Type      string `json:"type,omitempty"` // "control" or "data"
 }
 
-// RegisterResponse is sent by the server after registration.
-type RegisterResponse struct {
+// TunnelResponse is sent by the server after registration.
+type TunnelResponse struct {
 	// Subdomain is the assigned subdomain.
 	Subdomain string `json:"subdomain"`
 	// PublicURL is the full URL to access the tunnel.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -14,10 +15,13 @@ import (
 // Server manages the self-hosted tunnel server.
 // holds the state of the server and handles incoming connections.
 type Server struct {
-	domain          string
-	controlPort     int // port for client connections
-	publicPort      int // port for public http connections
-	tunnels         sync.Map
+	domain      string
+	controlPort int // port for client connections
+	publicPort  int // port for public http connections
+	tunnels     sync.Map
+
+	// TODO: use sync.Map;for v1 we are keeping it simple, single connection
+	dataConns       chan net.Conn
 	controlListener net.Listener
 	publicListener  net.Listener
 }
@@ -32,11 +36,13 @@ func NewServer(domain string, controlPort, publicPort int) *Server {
 		domain:      domain, // e.g. localtunnel.me
 		controlPort: controlPort,
 		publicPort:  publicPort,
+		dataConns:   make(chan net.Conn, 10),
 	}
 }
 
 // startControlPlane listens for incoming tunnel connections from clients.
 func (s *Server) startControlPlane() error {
+	// listen on control port, it will be used for client connections
 	addr := fmt.Sprintf(":%d", s.controlPort)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -83,11 +89,20 @@ func (s *Server) isClosed(err error) bool {
 func (s *Server) handleControlConnection(conn net.Conn) {
 	// 1. Read Request
 	var req protocol.TunnelRequest
+	// here we are reading the request from the client
 	if err := json.NewDecoder(conn).Decode(&req); err != nil {
 		// Failed to read JSON
 		conn.Close()
 		return
 	}
+
+	// for data connections, we are just storing the connection in a channel
+	// and returning immediately
+	if req.Type == protocol.TypeData {
+		s.dataConns <- conn
+		return
+	}
+
 	// 2. Assign Subdomain
 	subdomain := req.Subdomain
 	if subdomain == "" {
@@ -157,11 +172,66 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	_, err := fmt.Fprintf(w, "Tunnel proxy coming soon!")
-	if err != nil {
-		fmt.Println("Error writing to response writer", err)
+	// Grab the first available data connection
+	dataConn := <-s.dataConns
+	defer dataConn.Close()
+
+	// Hijack the underlying TCP connection from net/http.
+	//
+	// Normally, net/http owns the connection lifecycle and expects us
+	// to write an HTTP response using ResponseWriter.
+	//
+	// By calling Hijack(), we are telling net/http:
+	// "Stop managing this connection. Give me the raw TCP socket.
+	//  I will handle all reads/writes manually from now on."
+	//
+	// After this call:
+	// - We are no longer in HTTP abstraction land.
+	// - We must handle the raw TCP stream ourselves.
+	// - net/http will NOT send headers or manage keep-alive.
+	//
+	// Hijack only works for HTTP/1.x.
+	// It does NOT work for HTTP/2.
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		// we will send internal error to client with code and hide the details
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
 
+	// Hijack returns:
+	// 1) The raw TCP connection
+	// 2) The buffered reader/writer (we don't use it)
+	// 3) The error
+	//
+	// We immediately forward the request to the client connection
+	clientConn, _, err := hj.Hijack()
+	if err != nil {
+		return
+	}
+
+	defer clientConn.Close()
+
+	// Write the incoming HTTP request to the tunnel client
+	//
+	// r.Write() serializes the request back in to HTTP format:
+	// METHOD /path HTTP/1.1
+	// Headers: ...
+	// Body: ...
+	//
+	// r.Write(dataConn) sends the request to the tunnel client
+	// - This re-encodes the parsed request into bytes.
+	// - If this fails, the tunnel client will not receive anything.
+	// - At this point we are manually forwarding HTTP as raw bytes.
+	if err := r.Write(dataConn); err != nil {
+		return
+	}
+
+	// Forward the response from the tunnel client to the client
+	// - This copies the raw bytes from the tunnel client to the client
+	// - If this fails, the client will not receive anything
+	go io.Copy(clientConn, dataConn)
+	io.Copy(dataConn, clientConn)
 }
 
 // Stop gracefully shuts down the server.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/kernelshard/expose/internal/server/protocol"
+)
+
+// Server manages the self-hosted tunnel server.
+// holds the state of the server and handles incoming connections.
+type Server struct {
+	domain          string
+	controlPort     int // port for client connections
+	publicPort      int // port for public http connections
+	tunnels         sync.Map
+	controlListener net.Listener
+	publicListener  net.Listener
+}
+
+type ClientConnection struct {
+	conn      net.Conn
+	subdomain string
+}
+
+func NewServer(domain string, controlPort, publicPort int) *Server {
+	return &Server{
+		domain:      domain, // e.g. localtunnel.me
+		controlPort: controlPort,
+		publicPort:  publicPort,
+	}
+}
+
+// Start runs the server. It blocks until ctx is cancelled.
+func (s *Server) Start(ctx context.Context) error {
+	// 1. Setyp error channel to catch startup errors
+	errChan := make(chan error, 1)
+
+	// start control plane
+	go func() {
+		if err := s.startControlPlane(); err != nil {
+			errChan <- err
+			return
+		}
+	}()
+
+	// start public server
+	go func() {
+		if err := s.startPublicServer(); err != nil {
+			errChan <- err
+			return
+		}
+	}()
+	select {
+	case err := <-errChan:
+		return err
+	case <-ctx.Done():
+		return s.Stop()
+	}
+}
+
+// startControlPlane listens for incoming tunnel connections from clients.
+func (s *Server) startControlPlane() error {
+	addr := fmt.Sprintf("%d", s.controlPort)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	s.controlListener = ln
+
+	fmt.Printf("Control plane listening on %s\n", addr)
+
+	// accept incoming connections on the listener
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			// check if error is due to shutdown(listener close)
+			if s.isClosed(err) {
+				return nil
+			}
+			return err
+		}
+		go s.handleControlConnection(conn)
+	}
+}
+
+// startPublicServer listens for incoming public http connections from clients.
+func (s *Server) startPublicServer() error {
+	addr := fmt.Sprintf(":%d", s.publicPort)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	s.publicListener = ln
+	fmt.Println("Public server listening on :", addr)
+
+	// Use Go HTTP server
+	return http.Serve(ln, s)
+}
+
+func (s *Server) isClosed(err error) bool {
+	return err != nil && err.Error() != ""
+}
+
+// TODO: implement
+func (s *Server) handleControlConnection(conn net.Conn) {
+	// 1. Read Request
+	var req protocol.RegisterRequest
+	if err := json.NewDecoder(conn).Decode(&req); err != nil {
+		// Failed to read JSON
+		conn.Close()
+		return
+	}
+	// 2. Assign Subdomain
+	subdomain := req.Subdomain
+	if subdomain == "" {
+		subdomain, _ = GenerateRandomSubdomain()
+	}
+
+	// TODO: verify if subdomain is taken! for now let's assume it's not
+
+	// 3. Register the subdomain with the connection
+	client := ClientConnection{
+		conn:      conn,
+		subdomain: subdomain,
+	}
+
+	s.tunnels.Store(subdomain, client)
+	defer s.tunnels.Delete(subdomain) // cleanup when connection closes/done
+
+	// 4. Send Response
+	publicURL := fmt.Sprintf("http://%s.%s:%d", subdomain, s.domain, s.publicPort)
+	resp := protocol.RegisterResponse{
+		Subdomain: subdomain,
+		PublicURL: publicURL,
+	}
+	if err := json.NewEncoder(conn).Encode(resp); err != nil {
+		conn.Close()
+		return
+	}
+
+	/// 5. Wait for disconnect
+	// TODO: We loop here to keep the connection alive.
+	// If the client sends data (like a PING), we ignore it.
+	// If the client disconnects, Read returns an error and we
+	buf := make([]byte, 1)
+	_, _ = conn.Read(buf)
+	conn.Close()
+
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, err := fmt.Fprintf(w, "Tunnel proxy coming soon!")
+	if err != nil {
+		fmt.Println("Error writing to response writer", err)
+	}
+
+}
+
+// Stop gracefully shuts down the server.
+func (s *Server) Stop() error {
+	if s.controlListener != nil {
+		s.controlListener.Close()
+	}
+	if s.publicListener != nil {
+		s.publicListener.Close()
+	}
+	return nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,36 +35,6 @@ func NewServer(domain string, controlPort, publicPort int) *Server {
 	}
 }
 
-// Start runs the server. It blocks until ctx is cancelled.
-func (s *Server) Start(ctx context.Context) error {
-	// 1. Setyp error channel to catch startup errors
-	errChan := make(chan error, 1)
-
-	// start control plane
-	go func() {
-		if err := s.startControlPlane(); err != nil {
-			errChan <- err
-			return
-		}
-	}()
-
-	// start public server
-	go func() {
-		if err := s.startPublicServer(); err != nil {
-			errChan <- err
-			return
-		}
-	}()
-
-	// wait for either error or ctx to be done
-	select {
-	case err := <-errChan:
-		return err
-	case <-ctx.Done():
-		return s.Stop()
-	}
-}
-
 // startControlPlane listens for incoming tunnel connections from clients.
 func (s *Server) startControlPlane() error {
 	addr := fmt.Sprintf(":%d", s.controlPort)
@@ -156,6 +126,36 @@ func (s *Server) handleControlConnection(conn net.Conn) {
 
 }
 
+// Start runs the server. It blocks until ctx is cancelled.
+func (s *Server) Start(ctx context.Context) error {
+	// 1. Setyp error channel to catch startup errors
+	errChan := make(chan error, 1)
+
+	// start control plane
+	go func() {
+		if err := s.startControlPlane(); err != nil {
+			errChan <- err
+			return
+		}
+	}()
+
+	// start public server
+	go func() {
+		if err := s.startPublicServer(); err != nil {
+			errChan <- err
+			return
+		}
+	}()
+
+	// wait for either error or ctx to be done
+	select {
+	case err := <-errChan:
+		return err
+	case <-ctx.Done():
+		return s.Stop()
+	}
+}
+
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, err := fmt.Fprintf(w, "Tunnel proxy coming soon!")
 	if err != nil {
@@ -173,4 +173,12 @@ func (s *Server) Stop() error {
 		s.publicListener.Close()
 	}
 	return nil
+}
+
+// ControlAddr returns the address of the control plane.
+func (s *Server) ControlAddr() string {
+	if s.controlListener == nil {
+		return ""
+	}
+	return s.controlListener.Addr().String()
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,6 +55,8 @@ func (s *Server) Start(ctx context.Context) error {
 			return
 		}
 	}()
+
+	// wait for either error or ctx to be done
 	select {
 	case err := <-errChan:
 		return err
@@ -65,7 +67,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 // startControlPlane listens for incoming tunnel connections from clients.
 func (s *Server) startControlPlane() error {
-	addr := fmt.Sprintf("%d", s.controlPort)
+	addr := fmt.Sprintf(":%d", s.controlPort)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,7 +82,7 @@ func (s *Server) isClosed(err error) bool {
 // TODO: implement
 func (s *Server) handleControlConnection(conn net.Conn) {
 	// 1. Read Request
-	var req protocol.RegisterRequest
+	var req protocol.TunnelRequest
 	if err := json.NewDecoder(conn).Decode(&req); err != nil {
 		// Failed to read JSON
 		conn.Close()
@@ -107,7 +107,7 @@ func (s *Server) handleControlConnection(conn net.Conn) {
 
 	// 4. Send Response
 	publicURL := fmt.Sprintf("http://%s.%s:%d", subdomain, s.domain, s.publicPort)
-	resp := protocol.RegisterResponse{
+	resp := protocol.TunnelResponse{
 		Subdomain: subdomain,
 		PublicURL: publicURL,
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestServerLifeCycle(t *testing.T) {
+	// create a server with random port (0)
+	srv := NewServer("localhost", 0, 0)
+
+	// start in the background
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- srv.Start(ctx)
+	}()
+
+	// wait for listener to bind
+	time.Sleep(600 * time.Millisecond)
+
+	// Verify listeners exist
+	if srv.controlListener == nil {
+		t.Fatalf("Control listener not started")
+	}
+
+	// Connect to control plane
+	controlAddr := srv.controlListener.Addr().String()
+	conn, err := net.Dial("tcp", controlAddr)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer conn.Close()
+
+	// stop
+	cancel()
+
+	// wait for server to stop
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Errorf("Server errror: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for stop!")
+	}
+
+}

--- a/internal/server/subdomain.go
+++ b/internal/server/subdomain.go
@@ -1,0 +1,14 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+func GenerateRandomSubdomain() (string, error) {
+	bytes := make([]byte, 4) // 4 bytes = 8 hex chars
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}

--- a/internal/server/subdomain_test.go
+++ b/internal/server/subdomain_test.go
@@ -1,0 +1,21 @@
+package server
+
+import "testing"
+
+func TestGenerateRandomSubdomain(t *testing.T) {
+	// Generate two random subdomains and check if they are different
+	sub1, err := GenerateRandomSubdomain()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sub2, err := GenerateRandomSubdomain()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sub1 == sub2 {
+		t.Fatalf("subdomains are not random")
+	}
+	if len(sub2) != 8 {
+		t.Fatalf("expected 8 characters, got %d", len(sub2))
+	}
+}


### PR DESCRIPTION
Closes #25

## What
Adds `expose server` command so users can run their own tunnel server on any VPS.

## Changes
- `internal/server/` — TCP control plane + public HTTP server
- `internal/server/protocol/` — shared JSON types (RegisterRequest/Response)
- `internal/provider/selfhosted.go` — client-side Provider implementation
- `internal/cli/server.go` — new `expose server` command
- `internal/cli/tunnel.go` — added `--server` flag, refactored provider construction
- `README.md` — self-hosted usage section

## Usage
```bash
# On your VPS
expose server --domain=tunnel.mysite.com --control-port=7890 --public-port=8080

# On your laptop
expose tunnel --server=tunnel.mysite.com:7890
